### PR TITLE
Add support for on-the-fly decryption.

### DIFF
--- a/source/aes.h
+++ b/source/aes.h
@@ -52,3 +52,32 @@
 #define AES_MODE_CBC_ENCRYPT    5
 #define AES_MODE_UNK6           6
 #define AES_MODE_UNK7           7
+#define AES_CCM_DECRYPT_MODE    (AES_MODE_CCM_DECRYPT << 27)
+#define AES_CCM_ENCRYPT_MODE    (AES_MODE_CCM_ENCRYPT << 27)
+#define AES_CTR_MODE            (AES_MODE_CTR << 27)
+#define AES_CBC_DECRYPT_MODE    (AES_MODE_CBC_DECRYPT << 27)
+#define AES_CBC_ENCRYPT_MODE    (AES_MODE_CBC_ENCRYPT << 27)
+#define AES_ECB_DECRYPT_MODE    (AES_MODE_UNK6 << 27)
+#define AES_ECB_ENCRYPT_MODE    (AES_MODE_UNK7 << 27)
+
+#define AES_BIG_INPUT      1
+#define AES_LITTLE_INPUT   0
+#define AES_NORMAL_INPUT   4
+#define AES_REVERSED_INPUT 0
+#define AES_BLOCK_SIZE 0x10
+
+void add_ctr(void* ctr, u32 carry);
+
+void setup_aeskeyX(u8 keyslot, void* keyx);
+void decrypt(void* key, void* iv, void* inbuf, void* outbuf, size_t size);
+void setup_aeskey(u32 keyno, int value, void* key);
+void use_aeskey(u32 keyno);
+void set_ctr(int mode, void* iv);
+void aes_decrypt(void* inbuf, void* outbuf, void* iv, size_t size, u32 mode);
+void aes_fifos(void* inbuf, void* outbuf, size_t blocks);
+void set_aeswrfifo(u32 value);
+u32 read_aesrdfifo(void);
+u32 aes_getwritecount();
+u32 aes_getreadcount();
+u32 aescnt_checkwrite();
+u32 aescnt_checkread();

--- a/source/crypto.c
+++ b/source/crypto.c
@@ -1,0 +1,212 @@
+/* original version by megazig */
+#include "crypto.h"
+
+void setup_aeskeyX(u8 keyslot, void* keyx)
+{
+    u32 * _keyx = (u32*)keyx;
+    *REG_AESKEYCNT = (*REG_AESKEYCNT >> 6 << 6) | keyslot| 0x80;
+    *REG_AESKEYXFIFO = _keyx[0];
+    *REG_AESKEYXFIFO = _keyx[1];
+    *REG_AESKEYXFIFO = _keyx[2];
+    *REG_AESKEYXFIFO = _keyx[3];
+}
+
+void decrypt(void* key, void* iv, void* inbuf, void* outbuf, size_t size)
+{
+    setup_aeskey(0x2C, AES_BIG_INPUT|AES_NORMAL_INPUT, key);
+    use_aeskey(0x2C);
+    aes_decrypt(inbuf, outbuf, iv, size / AES_BLOCK_SIZE, AES_CTR_MODE);
+}
+
+void setup_aeskey(u32 keyno, int value, void* key)
+{
+    volatile u32* aes_regs[] =
+    {
+        (volatile u32*)0x19009060,
+        (volatile u32*)0x10009090,
+        (volatile u32*)0x100090C0,
+        (volatile u32*)0x100090F0
+    };
+    u32 * _key = (u32*)key;
+    *REG_AESCNT = (*REG_AESCNT & ~(AES_CNT_INPUT_ENDIAN|AES_CNT_INPUT_ORDER)) | (value << 23);
+    if (keyno > 3)
+    {
+        if (keyno > 0x3F)
+            return;
+        *REG_AESKEYCNT = (*REG_AESKEYCNT >> 6 << 6) | (u8)keyno | 0x80;
+        *REG_AESKEYFIFO = _key[0];
+        *REG_AESKEYFIFO = _key[1];
+        *REG_AESKEYFIFO = _key[2];
+        *REG_AESKEYFIFO = _key[3];
+    }
+    else
+    {
+        volatile u32* aes_reg = aes_regs[keyno];
+        if (value & 0x4)
+        {
+            aes_reg[0] = _key[3];
+            aes_reg[1] = _key[2];
+            aes_reg[2] = _key[1];
+            aes_reg[3] = _key[0];
+        }
+        else
+        {
+            aes_reg[0] = _key[0];
+            aes_reg[1] = _key[1];
+            aes_reg[2] = _key[2];
+            aes_reg[3] = _key[3];
+        }
+    }
+}
+
+void use_aeskey(u32 keyno)
+{
+    if (keyno > 0x3F)
+        return;
+    *REG_AESKEYSEL = keyno;
+    *REG_AESCNT    = *REG_AESCNT | 0x04000000; /* mystery bit */
+}
+
+void set_ctr(int mode, void* iv)
+{
+    u32 * _iv = (u32*)iv;
+    *REG_AESCNT = (*REG_AESCNT & ~(AES_CNT_INPUT_ENDIAN|AES_CNT_INPUT_ORDER)) | (mode << 23);
+    if (mode & AES_NORMAL_INPUT)
+    {
+        *(REG_AESCTR + 0) = _iv[3];
+        *(REG_AESCTR + 1) = _iv[2];
+        *(REG_AESCTR + 2) = _iv[1];
+        *(REG_AESCTR + 3) = _iv[0];
+    }
+    else
+    {
+        *(REG_AESCTR + 0) = _iv[0];
+        *(REG_AESCTR + 1) = _iv[1];
+        *(REG_AESCTR + 2) = _iv[2];
+        *(REG_AESCTR + 3) = _iv[3];
+    }
+}
+
+void add_ctr(void* ctr, u32 carry)
+{
+    u32 counter[4];
+    u8 *outctr = (u8 *) ctr;
+    u32 sum;
+    int32_t i;
+
+    for(i=0; i<4; i++) {
+        counter[i] = (outctr[i*4+0]<<24) | (outctr[i*4+1]<<16) | (outctr[i*4+2]<<8) | (outctr[i*4+3]<<0);
+    }
+
+    for(i=3; i>=0; i--)
+    {
+        sum = counter[i] + carry;
+        if (sum < counter[i]) {
+            carry = 1;
+        }
+        else {
+            carry = 0;
+        }
+        counter[i] = sum;
+    }
+
+    for(i=0; i<4; i++)
+    {
+        outctr[i*4+0] = counter[i]>>24;
+        outctr[i*4+1] = counter[i]>>16;
+        outctr[i*4+2] = counter[i]>>8;
+        outctr[i*4+3] = counter[i]>>0;
+    }
+}
+
+static void _decrypt(u32 value, void* inbuf, void* outbuf, size_t blocks)
+{
+    *REG_AESCNT = 0;
+    *REG_AESBLKCNT = blocks << 16;
+    *REG_AESCNT = value |
+                  AES_CNT_START |
+                  AES_CNT_INPUT_ORDER |
+                  AES_CNT_OUTPUT_ORDER |
+                  AES_CNT_INPUT_ENDIAN |
+                  AES_CNT_OUTPUT_ENDIAN |
+                  AES_CNT_FLUSH_READ |
+                  AES_CNT_FLUSH_WRITE;
+    aes_fifos(inbuf, outbuf, blocks);
+}
+
+void aes_decrypt(void* inbuf, void* outbuf, void* iv, size_t size, u32 mode)
+{
+    u32 in  = (u32)inbuf;
+    u32 out = (u32)outbuf;
+    size_t block_count = size;
+    size_t blocks;
+    while (block_count != 0)
+    {
+        blocks = (block_count >= 0xFFFF) ? 0xFFFF : block_count;
+        _decrypt(mode, (void*)in, (void*)out, blocks);
+        in  += blocks * AES_BLOCK_SIZE;
+        out += blocks * AES_BLOCK_SIZE;
+        block_count -= blocks;
+    }
+}
+
+void aes_fifos(void* inbuf, void* outbuf, size_t blocks)
+{
+    u32 in  = (u32)inbuf;
+    if (!in) return;
+
+    u32 out = (u32)outbuf;
+    size_t curblock = 0;
+    while (curblock != blocks)
+    {
+        while (aescnt_checkwrite());
+
+        int ii = 0;
+        for (ii = in; ii != in + AES_BLOCK_SIZE; ii += 4)
+        {
+            set_aeswrfifo( *(u32*)(ii) );
+        }
+        if (out)
+        {
+            while (aescnt_checkread()) ;
+            for (ii = out; ii != out + AES_BLOCK_SIZE; ii += 4)
+            {
+                *(u32*)ii = read_aesrdfifo();
+            }
+        }
+        curblock++;
+    }
+}
+
+void set_aeswrfifo(u32 value)
+{
+    *REG_AESWRFIFO = value;
+}
+
+u32 read_aesrdfifo(void)
+{
+    return *REG_AESRDFIFO;
+}
+
+u32 aes_getwritecount()
+{
+    return *REG_AESCNT & 0x1F;
+}
+
+u32 aes_getreadcount()
+{
+    return (*REG_AESCNT >> 5) & 0x1F;
+}
+
+u32 aescnt_checkwrite()
+{
+    size_t ret = aes_getwritecount();
+    return (ret > 0xF);
+}
+
+u32 aescnt_checkread()
+{
+    size_t ret = aes_getreadcount();
+    return (ret <= 3);
+}
+

--- a/source/crypto.h
+++ b/source/crypto.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "common.h"
+
+#define AES_BIG_INPUT      1
+#define AES_LITTLE_INPUT   0
+#define AES_NORMAL_INPUT   4
+#define AES_REVERSED_INPUT 0
+#define AES_BLOCK_SIZE 0x10
+
+#define AES_CCM_DECRYPT_MODE (0 << 27)
+#define AES_CCM_ENCRYPT_MODE (1 << 27)
+#define AES_CTR_MODE         (2 << 27)
+#define AES_CTR_MODE         (2 << 27)
+#define AES_CBC_DECRYPT_MODE (4 << 27)
+#define AES_CBC_ENCRYPT_MODE (5 << 27)
+#define AES_ECB_DECRYPT_MODE (6 << 27)
+#define AES_ECB_ENCRYPT_MODE (7 << 27)
+
+#define REG_AESCNT     ((volatile u32*)0x10009000)
+#define REG_AESBLKCNT  ((volatile u32*)0x10009004)
+#define REG_AESWRFIFO  ((volatile u32*)0x10009008)
+#define REG_AESRDFIFO  ((volatile u32*)0x1000900C)
+#define REG_AESKEYSEL  ((volatile u8 *)0x10009010)
+#define REG_AESKEYCNT  ((volatile u8 *)0x10009011)
+#define REG_AESCTR     ((volatile u32*)0x10009020)
+#define REG_AESKEYFIFO ((volatile u32*)0x10009108)
+#define REG_AESKEYXFIFO ((volatile u32*)0x10009104)
+
+#define AES_CNT_START         0x80000000
+#define AES_CNT_INPUT_ORDER   0x02000000
+#define AES_CNT_OUTPUT_ORDER  0x01000000
+#define AES_CNT_INPUT_ENDIAN  0x00800000
+#define AES_CNT_OUTPUT_ENDIAN 0x00400000
+#define AES_CNT_FLUSH_READ    0x00000800
+#define AES_CNT_FLUSH_WRITE   0x00000400
+
+void add_ctr(void* ctr, u32 carry);
+
+void setup_aeskeyX(u8 keyslot, void* keyx);
+void decrypt(void* key, void* iv, void* inbuf, void* outbuf, size_t size);
+void setup_aeskey(u32 keyno, int value, void* key);
+void use_aeskey(u32 keyno);
+void set_ctr(int mode, void* iv);
+void aes_decrypt(void* inbuf, void* outbuf, void* iv, size_t size, u32 mode);
+void aes_fifos(void* inbuf, void* outbuf, size_t blocks);
+void set_aeswrfifo(u32 value);
+u32 read_aesrdfifo(void);
+u32 aes_getwritecount();
+u32 aes_getreadcount();
+u32 aescnt_checkwrite();
+u32 aescnt_checkread();

--- a/source/main.c
+++ b/source/main.c
@@ -2,8 +2,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include "crypto.h"
 #include "draw.h"
 #include "hid.h"
+#include "ncch.h"
 #include "fatfs/ff.h"
 #include "gamecart/protocol.h"
 #include "gamecart/command_ctr.h"
@@ -26,32 +28,201 @@ static void wait_key(void) {
     InputWait();
 }
 
+static void ncch_get_counter(NCCH_Header* header, u8 counter[16], u8 type) {
+    u32 version = header->version;
+    u32 mediaunitsize = 0x200; // TODO
+    u8* partitionid = header->partition_id;
+    u32 i;
+    u32 x = 0;
+
+    memset(counter, 0, 16);
+
+    if (version == 2 || version == 0)
+    {
+        for(i=0; i<8; i++)
+            counter[i] = partitionid[7-i];
+        counter[8] = type;
+    }
+    else if (version == 1)
+    {
+        if (type == 1/*NCCHTYPE_EXHEADER*/)
+            x = 0x200;
+        else if (type == 2/*NCCHTYPE_EXEFS*/)
+            x = header->exefs_offset * mediaunitsize;
+        else if (type == 3/*NCCHTYPE_ROMFS*/)
+            x = header->romfs_offset * mediaunitsize;
+
+        for(i=0; i<8; i++)
+            counter[i] = partitionid[i];
+        for(i=0; i<4; i++)
+            counter[12+i] = x>>((3-i)*8);
+    }
+}
+
+// Generate list of encrypted data blocks, ordered by file offset
+typedef struct {
+    uint32_t addr; // mediaUnits
+    uint32_t size; // mediaUnits
+    uint32_t uses_7x_crypto;
+    uint32_t pad;
+    u8 ctr[16] __attribute__((aligned(16)));
+    u8 keyY[16] __attribute__((aligned(16)));
+} EncryptedArea;
+
 struct Context {
+    u32 decrypt;
+
     u8* buffer;
     size_t buffer_size;
 
     u32 cart_size;
     u32 media_unit;
+
+    EncryptedArea areas[16];
+    int num_areas;
+
+    NCCH_Header ncchs[8]; // one ncch per partition
+
 };
 
-int dump_cart_region(u32 start_sector, u32 end_sector, FIL* output_file, struct Context* ctx) {
+static void find_encrypted_ncch_regions(NCCH_Header* ncch, NCSD_Header* ncsd, unsigned partition, struct Context* ctx, u32 initial_sector, u32 dumped) {
+    u8* source = ctx->buffer;
+    u8* dest = (u8*)ncch;
+    u32 size = sizeof(NCCH_Header);
+    Debug("Detected NCCH: %p, %p, %x, %x", source, dest, size);
+    if (ncsd->partition_table[partition].offset > initial_sector) {
+        u32 delta = (ncsd->partition_table[partition].offset - initial_sector) * ctx->media_unit;
+        source += delta;
+    }
+    if (ncsd->partition_table[partition].offset < initial_sector) {
+        // TODO: I don't think this can ever happen. If it does happen, I don't think it works correctly.
+        u32 delta = (initial_sector - ncsd->partition_table[partition].offset) * ctx->media_unit;
+        dest += delta;
+        size -= delta;
+    }
+    // TODO: Should make more special cases, I think.
+    memcpy(dest, source, size);
+
+    // If the header is complete
+    if (initial_sector + dumped >= ncsd->partition_table[partition].offset + sizeof(NCCH_Header)) {
+        if (ncch->flags[3] != 0) {
+            // This cartridge uses the new crypto method introduced in system version 7.x.
+            // TODO: Set the uses_7x_crypto field of the affected encrypted areas appropriately.
+            // TODO: System versions older than 7.x require the keyX to be given by the user. If the key is not given, we should abort dumping.
+            Debug("ERROR: Cartridge uses 7.x crypto.");
+            Debug("uncart does not support this, yet.");
+            Debug("Perform a raw dump and decrypt it with");
+            Debug("an external tool.");
+            Debug("Dumping process aborted.");
+            wait_key();
+            // TODO: Come up with a cleaner method of exiting here.
+            exit(1);
+        }
+
+        // TODO: Consider checking for other flags, in particular the 9.6.0 keyY generator
+
+        if (ncch->extended_header_size) {
+            ctx->areas[ctx->num_areas].addr = ncsd->partition_table[partition].offset + sizeof(NCCH_Header) / ctx->media_unit;
+            ctx->areas[ctx->num_areas].size = 0x800 / ctx->media_unit; // NOTE: ncchs->extended_header_size doesn't cover the full exheader!
+            ctx->areas[ctx->num_areas].uses_7x_crypto = 0;
+            memcpy(ctx->areas[ctx->num_areas].keyY, ncch->signature, sizeof(ctx->areas[ctx->num_areas].keyY));
+            ncch_get_counter(ncch, ctx->areas[ctx->num_areas].ctr, 1);
+            ctx->num_areas++;
+        }
+
+        if (ncch->exefs_offset && ncch->exefs_size) {
+            ctx->areas[ctx->num_areas].addr = ncsd->partition_table[partition].offset + ncch->exefs_offset;
+            ctx->areas[ctx->num_areas].size = ncch->exefs_size;
+            memcpy(ctx->areas[ctx->num_areas].keyY, ncch->signature, sizeof(ctx->areas[ctx->num_areas].keyY));
+            ctx->areas[ctx->num_areas].uses_7x_crypto = 0;
+            ncch_get_counter(ncch, ctx->areas[ctx->num_areas].ctr, 2);
+            ctx->num_areas++;
+        }
+        if (ncch->romfs_offset && ncch->romfs_size) {
+            ctx->areas[ctx->num_areas].addr = ncsd->partition_table[partition].offset + ncch->romfs_offset;
+            ctx->areas[ctx->num_areas].uses_7x_crypto = 0;
+            ctx->areas[ctx->num_areas].size = ncch->romfs_size;
+            memcpy(ctx->areas[ctx->num_areas].keyY, ncch->signature, sizeof(ctx->areas[ctx->num_areas].keyY));
+            ncch_get_counter(ncch, ctx->areas[ctx->num_areas].ctr, 3);
+            ctx->num_areas++;
+        }
+    }
+}
+
+static void decrypt_region(EncryptedArea area, struct Context* ctx, u32 initial_sector, u32 dumped) {
+    u32 keyslot = (area.uses_7x_crypto == 0xA) ? 0x18 : (area.uses_7x_crypto != 0) ? 0x25 : 0x2c;
+    setup_aeskey(keyslot, AES_BIG_INPUT | AES_NORMAL_INPUT, area.keyY);
+    use_aeskey(keyslot);
+
+    static const uint8_t zero_buf[16] __attribute__((aligned(16))) = {0};
+    static const uint8_t dec_buf[16] __attribute__((aligned(16))) = {0};
+    u32 adr2 = (initial_sector < area.addr) ? area.addr : initial_sector;
+    u32 limit = initial_sector + dumped;
+    if (initial_sector + dumped > area.addr + area.size)
+        limit = area.addr + area.size;
+    adr2 *= ctx->media_unit / 16;
+    limit *= ctx->media_unit / 16;
+
+    Debug("Decrypting from %08x to %08x", adr2 * 16, limit * 16);
+
+    while (adr2 < limit) {
+        set_ctr(AES_BIG_INPUT | AES_NORMAL_INPUT, area.ctr);
+        aes_decrypt((void*)zero_buf, (void*)dec_buf, area.ctr, 1, AES_CTR_MODE);
+        add_ctr(area.ctr, 1);
+
+        u8* dest = ctx->buffer + adr2 * 16 - (initial_sector * ctx->media_unit);
+        for (int k = 0; k < 16; ++k) {
+            dest[k] ^= dec_buf[k];
+        }
+        adr2++;
+    }
+}
+
+int dump_cart_region(u32 start_sector, u32 end_sector, FIL* output_file, struct Context* ctx, NCSD_Header* ncsd) {
     const u32 read_size = 1 * 1024 * 1024 / ctx->media_unit; // 1MB
 
-    // Dump remaining data
     u32 current_sector = start_sector;
     while (current_sector < end_sector) {
+        ClearTop();
         unsigned int percentage = current_sector * 100 / ctx->cart_size;
         Debug("Dumping %08X / %08X - %3u%%", current_sector, ctx->cart_size, percentage);
 
+        // Read data from cartridge
         u8* read_ptr = ctx->buffer;
+        u32 dumped = 0;
+        const u32 initial_sector = current_sector;
         while (read_ptr < ctx->buffer + ctx->buffer_size && current_sector < end_sector) {
             Cart_Dummy();
             Cart_Dummy();
             CTR_CmdReadData(current_sector, ctx->media_unit, read_size, read_ptr);
             read_ptr += ctx->media_unit * read_size;
             current_sector += read_size;
+            dumped += read_size;
         }
 
+        if (ctx->decrypt) {
+            // If we have read (a part of) an NCCH header, update the list of encrypted areas
+            for (int partition = 0; partition < 8; ++partition) {
+                if (!ncsd->partition_table[partition].offset || !ncsd->partition_table[partition].size)
+                    continue;
+
+                if (initial_sector + dumped > ncsd->partition_table[partition].offset &&
+                    initial_sector < ncsd->partition_table[partition].offset + (sizeof(NCCH_Header) / ctx->media_unit)) {
+                    find_encrypted_ncch_regions(&ctx->ncchs[partition], ncsd, partition, ctx, initial_sector, dumped);
+                }
+            }
+
+            // Check if the currently dumped area is encrypted, and decrypt it if it is
+            for (int area = 0; area < ctx->num_areas; ++area) {
+                if (!(initial_sector + dumped >= ctx->areas[area].addr &&
+                      initial_sector < ctx->areas[area].addr + ctx->areas[area].size))
+                    continue;
+
+                decrypt_region(ctx->areas[area], ctx, initial_sector, dumped);
+            }
+        }
+
+        // Write dumped data to file
         u8* write_ptr = ctx->buffer;
         while (write_ptr < read_ptr) {
             unsigned int bytes_written = 0;
@@ -86,6 +257,8 @@ restart_program:
     u8* header = (u8*)0x23000000;
     memset(target, 0, target_buf_size); // Clear our buffer
 
+    NCSD_Header ncsd;
+
     *(vu32*)0x10000020 = 0; // InitFS stuff
     *(vu32*)0x10000020 = 0x340; // InitFS stuff
 
@@ -105,10 +278,15 @@ restart_program:
     // Read out the header 0x0000-0x1000
     Cart_Dummy();
     CTR_CmdReadData(0, mediaUnit, 0x1000 / mediaUnit, target);
+    memcpy(&ncsd, target, sizeof(ncsd));
 
     u32 NCSD_magic = *(u32*)(&target[0x100]);
     u32 cartSize = *(u32*)(&target[0x104]);
     Debug("Cart size: %llu MB", (u64)cartSize * (u64)mediaUnit / 1024ull / 1024ull);
+    Debug("%c%c%c%c", ncsd.magic[0], ncsd.magic[1], ncsd.magic[2], ncsd.magic[3]);
+    for (int partition = 0; partition < 8; ++partition) {
+        Debug("Partition %d: offset %x, size %x", partition,  ncsd.partition_table[partition].offset, ncsd.partition_table[partition].size);
+    }
     if (NCSD_magic != 0x4453434E) {
         Debug("NCSD magic not found in header!!!");
         Debug("Press A to continue anyway.");
@@ -121,7 +299,23 @@ restart_program:
         .buffer_size = target_buf_size,
         .cart_size = cartSize,
         .media_unit = mediaUnit,
+        .num_areas = 0,
     };
+
+    Debug("Press START to dump a decrypted image.");
+    Debug("Press SELECT to dump the raw, encrypted image.");
+    for (;;) {
+        u32 input = InputWait();
+        if (input & BUTTON_START) {
+            context.decrypt = 1;
+            break;
+        } else if (input & BUTTON_SELECT) {
+            context.decrypt = 0;
+            break;
+        } else {
+            Debug("Invalid input. Press START or SELECT");
+        }
+    }
 
     // Maximum number of blocks in a single file
     u32 file_max_blocks = 2u * 1024u * 1024u * 1024u / mediaUnit; // 2GB
@@ -129,9 +323,21 @@ restart_program:
 
     while (current_part * file_max_blocks < cartSize) {
         // Create output file
+        // File extension is "cci"/"3ds" for single-file dumps and "cciN"/"3dN" for split dumps
         char filename_buf[32];
-        char extension_digit = cartSize <= file_max_blocks ? 's' : '0' + current_part;
-        snprintf(filename_buf, sizeof(filename_buf), "/%.16s.3d%c", &header[0x150], extension_digit);
+        char* extension = (context.decrypt != 0) ? "cci" : "3d";
+        int filename_len = snprintf(filename_buf, sizeof(filename_buf), "/%.16s.%s", &header[0x150], extension);
+        if (cartSize <= file_max_blocks) {
+            if (context.decrypt == 0) {
+                filename_buf[filename_len++] = 's';
+                filename_buf[filename_len++] = '\0';
+            }
+        } else {
+            filename_buf[filename_len++] = '0' + current_part;
+            filename_buf[filename_len++] = '\0';
+        }
+
+
         Debug("Writing to file: \"%s\"", filename_buf);
         Debug("Change the SD card now and/or press a key.");
         Debug("(Or SELECT to cancel)");
@@ -157,7 +363,7 @@ restart_program:
         if (region_end > cartSize)
             region_end = cartSize;
 
-        if (dump_cart_region(region_start, region_end, &file, &context) < 0)
+        if (dump_cart_region(region_start, region_end, &file, &context, &ncsd) < 0)
             goto cleanup_file;
 
         if (current_part == 0) {

--- a/source/ncch.h
+++ b/source/ncch.h
@@ -1,0 +1,57 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// NCSD header
+
+typedef struct {
+    u8 signature[0x100];
+    u8 magic[4];
+    u32 size; // in media units
+    u8 media_id[8];
+    u8 unknown[16];
+    struct {
+        u32 offset;
+        u32 size;
+    } partition_table[8];
+} NCSD_Header;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// NCCH header
+
+typedef struct {
+    u8 signature[0x100];
+    u32 magic;
+    u32 content_size;
+    u8 partition_id[8];
+    u16 maker_code;
+    u16 version;
+    u8 reserved_0[4];
+    u8 program_id[8];
+    u8 reserved_1[0x10];
+    u8 logo_region_hash[0x20];
+    u8 product_code[0x10];
+    u8 extended_header_hash[0x20];
+    u32 extended_header_size;
+    u8 reserved_2[4];
+    u8 flags[8];
+    u32 plain_region_offset;
+    u32 plain_region_size;
+    u32 logo_region_offset;
+    u32 logo_region_size;
+    u32 exefs_offset;
+    u32 exefs_size;
+    u32 exefs_hash_region_size;
+    u8 reserved_3[4];
+    u32 romfs_offset;
+    u32 romfs_size;
+    u32 romfs_hash_region_size;
+    u8 reserved_4[4];
+    u8 exefs_super_block_hash[0x20];
+    u8 romfs_super_block_hash[0x20];
+} NCCH_Header;


### PR DESCRIPTION
Adds auto-decryption support, so that people can dump and decrypt games without having to reboot their 3DS multiple times and/or using a plethora of different tools. Everything (modulo verification) is done in uncart now.

* The user is prompted at the start of the program to press START or SELECT to choose between a decrypted or an encrypted dump.
* Encrypted dumps use the 3ds extension, while decrypted ones are dumped as .cci files (following common convention, as e.g. used by xorer)
* 7.x crypto is not supported, yet. Dumping will abort if an NCCH using this crypto method is encountered. I don't have anything to test 7.x crypto with, and it can be added at a later stage anyway.
* Introduces code from Citra (ncch.h) and Decrypt9 (crypto.c), both of which are compatible with GPLv2.

Please focus review on important aspects (user-facing things, code correctness, ...), rather than doing coding style reviews.
