### PR TITLE
Add support for dumping Development Carts.

### DIFF
--- a/source/gamecart/command_ctr.c
+++ b/source/gamecart/command_ctr.c
@@ -20,6 +20,7 @@ void CTR_CmdReadData(u32 sector, u32 length, u32 blocks, void* buffer)
     if(read_count++ > 10000)
     {
         CTR_CmdC5();
+        read_count = 0;
     }
 
     const u32 read_cmd[4] = {

--- a/source/gamecart/command_ctr.c
+++ b/source/gamecart/command_ctr.c
@@ -2,47 +2,50 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "draw.h"
 #include "command_ctr.h"
 
 #include "protocol_ctr.h"
 
-void CTR_CmdReadSectorSD(u8* aBuffer, u32 aSector)
+static int read_count = 0;
+
+void CTR_CmdC5()
 {
-    u64 adr = ((u64)0xBF << 56) | (aSector * 0x200);
-    const u32 readheader_cmd[4] = {
-        (u32)(adr >> 32),
-        (u32)(adr & 0xFFFFFFFF),
-        0x00000000, 0x00000000
-    };
-    CTR_SendCommand(readheader_cmd, 0x200, 1, 0x100802C, aBuffer);
+    static const u32 c5_cmd[4] = { 0xC5000000, 0x00000000, 0x00000000, 0x00000000 };
+    CTR_SendCommand(c5_cmd, 0, 1, 0x100002C, NULL);
 }
 
 void CTR_CmdReadData(u32 sector, u32 length, u32 blocks, void* buffer)
 {
+    if(read_count++ > 10000)
+    {
+        CTR_CmdC5();
+    }
+
     const u32 read_cmd[4] = {
         (0xBF000000 | (u32)(sector >> 23)),
         (u32)((sector << 9) & 0xFFFFFFFF),
         0x00000000, 0x00000000
     };
-    CTR_SendCommand(read_cmd, length, blocks, 0x100822C, buffer);
+    CTR_SendCommand(read_cmd, length, blocks, 0x704822C, buffer);
 }
 
 void CTR_CmdReadHeader(void* buffer)
 {
     static const u32 readheader_cmd[4] = { 0x82000000, 0x00000000, 0x00000000, 0x00000000 };
-    CTR_SendCommand(readheader_cmd, 0x200, 1, 0x4802C, buffer);
+    CTR_SendCommand(readheader_cmd, 0x200, 1, 0x704802C, buffer);
 }
 
 u32 CTR_CmdGetSecureId(u32 rand1, u32 rand2)
 {
     u32 id = 0;
     const u32 getid_cmd[4] = { 0xA2000000, 0x00000000, rand1, rand2 };
-    CTR_SendCommand(getid_cmd, 0x4, 1, 0x100802C, &id);
+    CTR_SendCommand(getid_cmd, 0x4, 1, 0x701002C, &id);
     return id;
 }
 
 void CTR_CmdSeed(u32 rand1, u32 rand2)
 {
-	const u32 seed_cmd[4] = { 0x83000000, 0x00000000, rand1, rand2 };
-    CTR_SendCommand(seed_cmd, 0, 1, 0x100822C, NULL);
+    const u32 seed_cmd[4] = { 0x83000000, 0x00000000, rand1, rand2 };
+    CTR_SendCommand(seed_cmd, 0, 1, 0x700822C, NULL);
 }


### PR DESCRIPTION
Adds support for dumping development carts, These use a different key slot and set the normal key for cart command encryption. This also fixes some of the cart flags so that the state doesn't become corrupted.